### PR TITLE
ci: add Discord notifications alongside Slack in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -88,9 +88,11 @@ jobs:
           cluster: ${{ env.ECS_CLUSTER }}
           wait-for-service-stability: true
 
+      # --- Slack notifications ---
       - name: Notify Success to Slack Channel
         id: slack-success
         if: success()
+        continue-on-error: true
         uses: slackapi/slack-github-action@v1.26.0
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
@@ -101,9 +103,51 @@ jobs:
       - name: Notify Failure to Slack Channel
         id: slack-failure
         if: failure()
+        continue-on-error: true
         uses: slackapi/slack-github-action@v1.26.0
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
           slack-message: "❌ Deployment Failed!\nRepository: ${{ needs.check-commit.outputs.REPO_NAME }}\nEnvironment: ${{ needs.check-commit.outputs.ENVIRONMENT }}\nBuild Status: ${{ job.status }}\nTriggered by: ${{ github.actor }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      # --- Discord notifications ---
+      - name: Notify Discord (Success)
+        if: success()
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then echo "no Discord webhook configured"; exit 0; fi
+          commit_or_pr_url="${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+          payload=$(jq -n \
+            --arg repo "${{ needs.check-commit.outputs.REPO_NAME }}" \
+            --arg envname "${{ needs.check-commit.outputs.ENVIRONMENT }}" \
+            --arg actor "${{ github.actor }}" \
+            --arg url "$commit_or_pr_url" \
+            '{content: (":white_check_mark: Deployment Successful!\n"
+              + "Repository: " + $repo + "\n"
+              + "Environment: " + $envname + "\n"
+              + "Build Status: success\n"
+              + "Triggered by: " + $actor + "\n"
+              + $url)}')
+          curl -sf -H "Content-Type: application/json" -X POST -d "$payload" "$DISCORD_WEBHOOK_URL"
+
+      - name: Notify Discord (Failure)
+        if: failure()
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then echo "no Discord webhook configured"; exit 0; fi
+          commit_or_pr_url="${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+          payload=$(jq -n \
+            --arg repo "${{ needs.check-commit.outputs.REPO_NAME }}" \
+            --arg envname "${{ needs.check-commit.outputs.ENVIRONMENT }}" \
+            --arg actor "${{ github.actor }}" \
+            --arg url "$commit_or_pr_url" \
+            '{content: (":x: Deployment Failed!\n"
+              + "Repository: " + $repo + "\n"
+              + "Environment: " + $envname + "\n"
+              + "Build Status: failure\n"
+              + "Triggered by: " + $actor + "\n"
+              + $url)}')
+          curl -sf -H "Content-Type: application/json" -X POST -d "$payload" "$DISCORD_WEBHOOK_URL"


### PR DESCRIPTION
cc @kenguyen

## Summary

Mirrors the Q3Labs org-wide dual-notification pattern ([devops PR #27](https://github.com/Quantum3-Labs/devops/pull/27), [brove PR #404](https://github.com/Just-Brove-It/brove/pull/404), [polypay_app PR #263](https://github.com/Poly-pay/polypay_app/pull/263)): the existing `Notify Success` / `Notify Failure` Slack steps now get `continue-on-error: true` and a matching pair of Discord steps that POST the same body to a webhook.

## File changed

`.github/workflows/deploy.yaml` — Discord success + failure appended after the Slack steps.

## Discord step pattern

Plain-text content (not embeds), built with `jq -n --arg`, sent via `curl -sf -X POST`. Each step:
- Reads `DISCORD_WEBHOOK_URL` from a secret env.
- If the secret is missing -> prints `no Discord webhook configured` and `exit 0` (workflow still passes, safe to merge before the secret is set).
- Otherwise -> posts a message that mirrors the existing Slack body line-by-line (REPO_NAME / ENVIRONMENT / actor / PR-or-commit URL), with `:white_check_mark:` / `:x:` shortcodes.

## New secret required

`DISCORD_WEBHOOK_URL` — add to the repo. Workflows keep passing without it.

## Test plan

- [ ] Add `DISCORD_WEBHOOK_URL` secret.
- [ ] Trigger `Deploy to ECS` via `workflow_dispatch` on `stg`; verify both Slack and Discord receive a `Deployment Successful!` message with the same body.
- [ ] Force a failure and verify both channels receive the failure message.
- [ ] Temporarily revoke the Slack token and confirm the workflow still passes (Slack step yellow via `continue-on-error`, Discord step succeeds).